### PR TITLE
Simplified installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,8 @@ Python package to work with Delft3D-FLOW model.
 ![grid_and_depth](doc/example/example1.jpg)
 
 ## Installation
-
-1. Clone or download the repository.
-
-2. To directly import this module, add the [delft3d](delft3d) folder to one of the following directories:
-    - Your project directories.
-
-    - The 'site-packages' folder of Python installation. When using Anaconda, the most likely path is C:/users/[username]/Anaconda3/Lib/site-packages.
-
-    - A user defined directory. Create a (`.pth`) file containing the path of the user defined directory. Add this (`.pth`) file to the 'site-packages' folder. Here is an example of (`.pth`) file:
-
-            D:/mymodule
-
-3. Download the following dependencies using pip or conda.
-
-    - pyproj
-    - matplotlib
-    - numpy
-    - pandas
+To install into the environment of your choosing, run:  
+`pip install git+https://github.com/Carlisle345748/Delft3D-Toolbox.git@master`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Python package to work with Delft3D-FLOW model.
 To install into the environment of your choosing, run:  
 `pip install git+https://github.com/Carlisle345748/Delft3D-Toolbox.git@master`
 
+To uninstall run `pip uninstall delft3d-toolbox`.
+
 ## Usage
 
 Here are some examples of using this package. See more details and examples in the [doc](doc/documentation.ipynb).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ dependencies = [
     "numpy",
     "pandas"
 ]
-license = "MIT license"
+license = "LICENSE.md"
 url = "https://github.com/Carlisle345748/Delft3D-Toolbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "delft3d-toolbox"
+version = "0.0.1"
+description = "Python package for running and modifying Delft3D-FLOW model"
+dependencies = [
+    "pyproj",
+    "matplotlib",
+    "numpy",
+    "pandas"
+]
+license = "MIT license"
+url = "https://github.com/Carlisle345748/Delft3D-Toolbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,5 @@ dependencies = [
     "numpy",
     "pandas"
 ]
-license = "LICENSE.md"
+license = {file = "LICENSE.md"}
 url = "https://github.com/Carlisle345748/Delft3D-Toolbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,4 @@ dependencies = [
     "pandas"
 ]
 license = {file = "LICENSE.md"}
-url = "https://github.com/Carlisle345748/Delft3D-Toolbox"
+urls = {repository = "https://github.com/Carlisle345748/Delft3D-Toolbox"}


### PR DESCRIPTION
Simplified installation instructions by specifying a `pyproject.toml` file (according to [setuptools](https://setuptools.pypa.io/)) so that pip can install using [VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/)

To test installation, run:
`pip install git+https://github.com/VeckoTheGecko/Delft3D-Toolbox.git@dev`

(the command in updated readme will only work once merged)